### PR TITLE
Fix Jekyll build by upgrading Ruby

### DIFF
--- a/.github/workflows/build-deploy-jekyll.yml
+++ b/.github/workflows/build-deploy-jekyll.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true # Runs bundle install and caches gems
 
       - name: Build Jekyll Site


### PR DESCRIPTION
## Summary
- use Ruby 3.2 in the build workflow

## Testing
- `bundle install`
- `bundle exec jekyll build`
- `python -m py_compile update_conferences.py`


------
https://chatgpt.com/codex/tasks/task_e_68422a11a03c83299bd797ee9ee374d6