### PR TITLE
Preserve conferences without explicit deadlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -4197,9 +4197,11 @@ $("#subject-select").multiselect({
             } catch (err) {
               console.log('Error processing conference deadline for', conf.id, err);
               el.find('.calendar').remove();
+              upcoming.push({ el: el, diff: null, order: index, deadlineMoment: null });
             }
           } else {
             el.find('.calendar').remove();
+            upcoming.push({ el: el, diff: null, order: index, deadlineMoment: null });
           }
         });
 

--- a/scripts/generate_pages.py
+++ b/scripts/generate_pages.py
@@ -325,9 +325,11 @@ $("#subject-select").multiselect({{
             }} catch (err) {{
               console.log('Error processing conference deadline for', conf.id, err);
               el.find('.calendar').remove();
+              upcoming.push({{ el: el, diff: null, order: index, deadlineMoment: null }});
             }}
           }} else {{
             el.find('.calendar').remove();
+            upcoming.push({{ el: el, diff: null, order: index, deadlineMoment: null }});
           }}
         }});
 


### PR DESCRIPTION
## Summary
- ensure conferences missing deadlines remain rendered in the upcoming list
- fall back to rendering conferences when deadline parsing fails so entries stay visible

## Testing
- python generate_conference_pages.py

------
https://chatgpt.com/codex/tasks/task_e_68fec4a8e1d48329b3d9f3bbdd497c13